### PR TITLE
raise disk-size for bigger default storage-pool,

### DIFF
--- a/esxi.json
+++ b/esxi.json
@@ -1,6 +1,6 @@
 {
   "variables": {
-    "disk_size": "10240",
+    "disk_size": "50240",
     "version": "6.7",
     "iso_url": "VMware-VMvisor-Installer-6.7.0.update03-14320388.x86_64.iso",
     "iso_checksum": "fcbaa4cd952abd9e629fb131b8f46a949844405d8976372e7e5b55917623fbe0",


### PR DESCRIPTION
hi,
10 gb of default storage is too small to run even simple nested virtual machines with only  1GB of defined ram, bcs ESX tends to create swap files exceeding the data-store limit. 50 GB is enough to start at least a tinylinux instance.