### PR TITLE
Vagrantfile: Set default memory size to at least 4 GB

### DIFF
--- a/Vagrantfile-uefi.template
+++ b/Vagrantfile-uefi.template
@@ -12,6 +12,7 @@ Vagrant.configure(2) do |config|
     lv.disk_bus = 'ide'
     lv.nic_model_type = 'vmxnet3'
     lv.video_type = 'vga'
+    lv.memory = 4000
     config.vm.synced_folder '.', '/vagrant', disabled: true
   end
 end

--- a/Vagrantfile-uefi.template
+++ b/Vagrantfile-uefi.template
@@ -12,7 +12,7 @@ Vagrant.configure(2) do |config|
     lv.disk_bus = 'ide'
     lv.nic_model_type = 'vmxnet3'
     lv.video_type = 'vga'
-    lv.memory = 4000
+    lv.memory = 4096
     config.vm.synced_folder '.', '/vagrant', disabled: true
   end
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -12,5 +12,6 @@ Vagrant.configure(2) do |config|
     lv.disk_bus = 'ide'
     lv.nic_model_type = 'vmxnet3'
     lv.video_type = 'vga'
+    lv.memory = 4000
   end
 end

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -12,6 +12,6 @@ Vagrant.configure(2) do |config|
     lv.disk_bus = 'ide'
     lv.nic_model_type = 'vmxnet3'
     lv.video_type = 'vga'
-    lv.memory = 4000
+    lv.memory = 4096
   end
 end


### PR DESCRIPTION
ESXi wont correctly boot with default memory settings for vagrant
virtual machines, requires at least 4 GB of Memory.

Set default memory size to 4 GB in the template file.